### PR TITLE
Added `drawCircles` option for polygon/lines points

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ See the next chapter for that.
 The following options can be used to modify the behavior of the addon:
 
 - `snapToGrid`: Specifies a grid to which a point is aligned (`default:1`)
+- `drawCircles`: Specifies the need to draw little circles around the line/polyline/polygon points (`default: true`)
 
 **Note** that you can specify the options only on the first call. When you want to change the options while drawing use `polygon.draw('params', key, value)` This is useful when you want to activate the grid-option when ctrl or soemthing is pressed.
 

--- a/src/lineable.js
+++ b/src/lineable.js
@@ -15,9 +15,10 @@
             this.el.plot(arr);
 
             // We draw little circles around each point
-            // This is absolutely not needed and maybe removed in a later release
-            this.drawCircles();
-
+            // This can be disabled by setting { drawCircles: false } option
+            if (this.options.drawCircles) {
+                this.drawCircles();
+            }
         },
 
 
@@ -32,7 +33,10 @@
             }
 
             this.el.plot(arr);
-            this.drawCircles();
+
+            if (this.options.drawCircles) {
+                this.drawCircles();
+            }
         },
 
         point:function(e){
@@ -45,7 +49,10 @@
                 arr.push(this.snapToGrid([p.x, p.y]));
 
                 this.el.plot(arr);
-                this.drawCircles();
+
+                if (this.options.drawCircles) {
+                    this.drawCircles();
+                }
 
                 // Fire the `drawpoint`-event, which holds the coords of the new Point
                 this.el.fire('drawpoint', {event:e, p:{x:p.x, y:p.y}, m:this.m});

--- a/src/svg.draw.js
+++ b/src/svg.draw.js
@@ -222,7 +222,8 @@
 
     // Default values. Can be changed for the whole project if needed
     SVG.Element.prototype.draw.defaults = {
-        snapToGrid: 1        // Snaps to a grid of `snapToGrid` px
+        snapToGrid: 1,        // Snaps to a grid of `snapToGrid` px
+        drawCircles: true     // Draw little circles around line/polyline/polygon points
     };
 
     SVG.Element.prototype.draw.extend = function(name, obj){


### PR DESCRIPTION
Fix for the [issue #59](https://github.com/svgdotjs/svg.draw.js/issues/59): added a `drawCircles` option to control the render for the small circles around polyline/line points.