### PR TITLE
Use `pointermove` instead of `mousemove` to allow touch interactions to work

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@svgdotjs/svg.draw.js",
-  "version": "3.0.1",
+  "version": "3.0.2",
   "description": "An extension for svg.js which allows to draw elements with mouse",
   "type": "module",
   "keywords": [

--- a/src/svg.draw.js
+++ b/src/svg.draw.js
@@ -87,7 +87,7 @@ class PaintHandler {
     this.el.fire('drawstart', { event: event, p: this.p, m: this.m })
 
     // We need to bind the update-function to the mousemove event to keep track of the cursor
-    on(window, 'mousemove.draw', function (e) {
+    on(window, 'pointermove.draw', function (e) {
       _this.update(e)
     })
 
@@ -120,7 +120,7 @@ class PaintHandler {
     }
 
     // Unbind from all events
-    off(window, 'mousemove.draw')
+    off(window, 'pointermove.draw')
     this.parent.off('click.draw')
 
     // remove Refernce to PaintHandler
@@ -222,7 +222,7 @@ class PaintHandler {
 }
 
 extend(Element, {
-  // Draw element with mouse
+  // Draw element with pointer
   draw: function (event, options, value) {
     // sort the parameters
     if (!(event instanceof Event || typeof event === 'string')) {


### PR DESCRIPTION
Just swaps out `mousemove` in favor of `pointermove`, which encapsulates mouse, touch, and pen events. Since `PointerEvent` inherits from `MouseEvent`, there is no other change needed for this to work. See [the MDN page for `PointerEvent`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent).

The other bound event, `click`, already handles touch events, so nothing else is needed to make this plugin compatible with touch events.

Should fix #66 (as far as `touchmove` -- the other two are fixed by using pointer events to cover all interactions)